### PR TITLE
Add macOS support

### DIFF
--- a/Disruptor/BuildConfig.h
+++ b/Disruptor/BuildConfig.h
@@ -62,6 +62,11 @@
 # define DISRUPTOR_OS_FAMILY_WINDOWS
 #else
 # define DISRUPTOR_OS_FAMILY_UNIX
+# ifdef __APPLE__
+#  define DISRUPTOR_OS_FAMILY_MACOS
+# else
+#  define DISRUPTOR_OS_FAMILY_LINUX
+# endif
 #endif
 
 #ifdef _DEBUG

--- a/Disruptor/CMakeLists.txt
+++ b/Disruptor/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(Disruptor)
 cmake_minimum_required(VERSION 2.6)
 
-find_package(Boost COMPONENTS system)
+find_package(Boost COMPONENTS system thread chrono)
 if(Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
     link_directories(${Boost_LIBRARY_DIRS})
@@ -27,6 +27,7 @@ set(Disruptor_sources
     stdafx.cpp
     ThreadPerTaskScheduler.cpp
     ThreadHelper_Linux.cpp
+    ThreadHelper_macOS.cpp
     ThreadHelper_Windows.cpp
     TimeoutBlockingWaitStrategy.cpp
     TypeInfo.cpp
@@ -114,6 +115,7 @@ set(Disruptor_headers
 )
 
 add_library(DisruptorShared SHARED ${Disruptor_sources})
+target_link_libraries(DisruptorShared ${Boost_LIBRARIES})
 set_target_properties(DisruptorShared PROPERTIES OUTPUT_NAME Disruptor)
 set_target_properties(DisruptorShared PROPERTIES VERSION ${DISRUPTOR_VERSION})
 set_target_properties(DisruptorShared PROPERTIES SOVERSION ${DISRUPTOR_VERSION_MAJOR})

--- a/Disruptor/ThreadHelper_Linux.cpp
+++ b/Disruptor/ThreadHelper_Linux.cpp
@@ -3,7 +3,7 @@
 
 #include "BuildConfig.h"
 
-#ifdef DISRUPTOR_OS_FAMILY_UNIX
+#ifdef DISRUPTOR_OS_FAMILY_LINUX
 
 #include <string>
 

--- a/Disruptor/ThreadHelper_macOS.cpp
+++ b/Disruptor/ThreadHelper_macOS.cpp
@@ -1,0 +1,151 @@
+#include "stdafx.h"
+#include "ThreadHelper.h"
+
+#include "BuildConfig.h"
+
+#ifdef DISRUPTOR_OS_FAMILY_MACOS
+
+#include <string>
+
+#include <pthread.h>
+#include <unistd.h>
+#include <sched.h>
+#include <cpuid.h>
+#include <sys/sysctl.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <mach/mach_types.h>
+#include <mach/thread_act.h>
+
+#define SYSCTL_CORE_COUNT   "machdep.cpu.core_count"
+
+#define CPUID(INFO, LEAF, SUBLEAF) __cpuid_count(LEAF, SUBLEAF, INFO[0], INFO[1], INFO[2], INFO[3])
+
+#define GETCPU(CPU) {                              \
+        uint32_t CPUInfo[4];                           \
+        CPUID(CPUInfo, 1, 0);                          \
+        /* CPUInfo[1] is EBX, bits 24-31 are APIC ID */ \
+        if ( (CPUInfo[3] & (1 << 9)) == 0) {           \
+          (CPU) = -1;  /* no APIC on chip */             \
+        }                                              \
+        else {                                         \
+          (CPU) = (unsigned)CPUInfo[1] >> 24;                    \
+        }                                              \
+        if ((CPU) < 0) (CPU) = 0;                          \
+      }
+
+namespace Disruptor
+{
+namespace ThreadHelper
+{
+    typedef struct cpu_set {
+        uint32_t    count;
+    } cpu_set_t;
+
+    static inline void CPU_ZERO(cpu_set_t *cs) { cs->count = 0; }
+
+    static inline void CPU_SET(int num, cpu_set_t *cs) { cs->count |= (1 << num); }
+
+    static inline int CPU_ISSET(int num, cpu_set_t *cs) { return (cs->count & (1 << num)); }
+
+    int sched_getaffinity(pid_t pid, size_t cpu_size, cpu_set_t *cpu_set)
+    {
+        (void) pid;
+        (void) cpu_size;
+
+        int32_t core_count = 0;
+        size_t  len = sizeof(core_count);
+        int ret = sysctlbyname(SYSCTL_CORE_COUNT, &core_count, &len, 0, 0);
+        if (ret) {
+            return -1;
+        }
+        cpu_set->count = 0;
+        for (int i = 0; i < core_count; i++) {
+            cpu_set->count |= (1 << i);
+        }
+
+        return 0;
+    }
+
+    int pthread_setaffinity_np(pthread_t thread, size_t cpu_size,
+                               cpu_set_t *cpu_set)
+    {
+        thread_port_t mach_thread;
+        int core = 0;
+
+        for (core = 0; core < 8 * (int)cpu_size; core++) {
+            if (CPU_ISSET(core, cpu_set)) break;
+        }
+
+        thread_affinity_policy_data_t policy = { core };
+        mach_thread = pthread_mach_thread_np(thread);
+        thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY,
+                          (thread_policy_t)&policy, 1);
+        return 0;
+    }
+
+
+    size_t getProcessorCount()
+    {
+        return static_cast<size_t>(sysconf(_SC_NPROCESSORS_CONF));
+    }
+
+    uint32_t getCurrentProcessor()
+    {
+        uint32_t cpu_id;
+
+        GETCPU(cpu_id);
+
+        return cpu_id;
+    }
+
+    bool setThreadAffinity(const AffinityMask& mask)
+    {
+        cpu_set_t cpuSet;
+        CPU_ZERO(&cpuSet);
+
+        for (size_t i = 0; i < mask.size(); ++i)
+        {
+            if (mask.test(i))
+                CPU_SET(i, &cpuSet);
+        }
+
+        return pthread_setaffinity_np(pthread_self(), sizeof(cpuSet), &cpuSet) == 0;
+    }
+
+    AffinityMask getThreadAffinity()
+    {
+        AffinityMask mask;
+
+        cpu_set_t cpuSet;
+        CPU_ZERO(&cpuSet);
+        if (sched_getaffinity(0, sizeof(cpuSet), &cpuSet) == 0)
+        {
+            int processorCount = getProcessorCount();
+            int maskSize = (int) mask.size();
+            for (int i = 0; i < processorCount && i < maskSize; ++i)
+            {
+                if (CPU_ISSET(i, &cpuSet))
+                    mask.set(i);
+            }
+        }
+
+        return mask;
+    }
+
+    uint32_t getCurrentThreadId()
+    {
+        uint64_t result;
+        pthread_threadid_np(NULL, &result);
+        return (uint32_t) result;
+    }
+
+    void setThreadName(const std::string& name)
+    {
+        pthread_setname_np(name.c_str());
+    }
+
+} // namespace ThreadHelper
+} // namespace Disruptor
+
+#endif // DISRUPTOR_OS_FAMILY_UNIX


### PR DESCRIPTION
Hi,

First thank you for this great piece of software. Just FYI that I ported it to macOS for evaluation on my machine. All the tests passed without a hitch and the performance stats are attached below.

Best,

Fan Jiang

(The machine is an i7-8700K @4.3GHz with 32GB of memory)
```
Test name (ALL by default):   ?

Latency Test to run => PingPongSequencedLatencyTest, Runs => 3
Starting latency tests
binding to core 1
binding to core 0
Run: Duration (s): 24.2, Latency: min: 3.73 us, mean: 7 us, max: 1.43 ms, Q99.99: 51.1 us, Q99.9: 19.6 us, Q99: 11 us, Q98: 9.25 us, Q95: 7.57 us, Q93: 7.36 us, Q90: 7.24 us, Q50: 6.86 us
binding to core 1
binding to core 0
Run: Duration (s): 24.4, Latency: min: 3.6 us, mean: 7.06 us, max: 1.73 ms, Q99.99: 51.8 us, Q99.9: 24.8 us, Q99: 12 us, Q98: 10.2 us, Q95: 7.97 us, Q93: 7.47 us, Q90: 7.26 us, Q50: 6.86 us
binding to core 0
binding to core 1
Run: Duration (s): 24.3, Latency: min: 313 ns, mean: 7.03 us, max: 350 us, Q99.99: 51.5 us, Q99.9: 21.7 us, Q99: 11.7 us, Q98: 10.1 us, Q95: 7.96 us, Q93: 7.52 us, Q90: 7.27 us, Q50: 6.84 us
Throughput Test to run => OneToOneRawBatchThroughputTest, Runs => 7
Starting throughput tests
Run: Ops: 643 603 976 - Duration (s): 3.11
Run: Ops: 642 391 340 - Duration (s): 3.11
Run: Ops: 624 379 522 - Duration (s): 3.2
Run: Ops: 648 166 272 - Duration (s): 3.09
Run: Ops: 642 900 561 - Duration (s): 3.11
Run: Ops: 642 843 941 - Duration (s): 3.11
Run: Ops: 649 735 638 - Duration (s): 3.08
Throughput Test to run => OneToOneRawThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 1
Run: Ops: 56 409 008 - Duration (s): 3.55
binding to core 0
binding to core 1
Run: Ops: 55 760 008 - Duration (s): 3.59
binding to core 0
binding to core 1
Run: Ops: 56 448 157 - Duration (s): 3.54
binding to core 0
binding to core 1
Run: Ops: 58 024 329 - Duration (s): 3.45
binding to core 0
binding to core 1
Run: Ops: 55 330 988 - Duration (s): 3.61
binding to core 0
binding to core 1
Run: Ops: 57 415 465 - Duration (s): 3.48
binding to core 0
binding to core 1
Run: Ops: 55 454 997 - Duration (s): 3.61
Throughput Test to run => OneToOneSequencedBatchThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 1
Run: Ops: 384 729 471 - Duration (s): 2.6
binding to core 0
binding to core 1
Run: Ops: 386 647 215 - Duration (s): 2.59
binding to core 0
binding to core 1
Run: Ops: 386 474 624 - Duration (s): 2.59
binding to core 0
binding to core 1
Run: Ops: 387 625 445 - Duration (s): 2.58
binding to core 0
binding to core 1
Run: Ops: 388 768 629 - Duration (s): 2.57
binding to core 0
binding to core 1
Run: Ops: 387 378 735 - Duration (s): 2.58
binding to core 0
binding to core 1
Run: Ops: 387 056 370 - Duration (s): 2.58
Throughput Test to run => OneToOneSequencedLongArrayThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 1
Run: Ops: 1 712 732 594 - Duration (s): 1.2
binding to core 0
binding to core 1
Run: Ops: 1 650 651 797 - Duration (s): 1.24
binding to core 0
binding to core 1
Run: Ops: 1 670 673 400 - Duration (s): 1.23
binding to core 0
binding to core 1
Run: Ops: 1 695 823 289 - Duration (s): 1.21
binding to core 0
binding to core 1
Run: Ops: 1 622 324 708 - Duration (s): 1.26
binding to core 0
binding to core 1
Run: Ops: 1 527 741 411 - Duration (s): 1.34
binding to core 0
binding to core 1
Run: Ops: 1 587 040 819 - Duration (s): 1.29
Throughput Test to run => OneToOneSequencedPollerThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 1
Run: Ops: 26 737 438 - Duration (s): 3.74
binding to core 0
binding to core 1
Run: Ops: 26 003 163 - Duration (s): 3.85
binding to core 0
binding to core 1
Run: Ops: 26 121 466 - Duration (s): 3.83
binding to core 0
binding to core 1
Run: Ops: 25 439 803 - Duration (s): 3.93
binding to core 0
binding to core 1
Run: Ops: 25 373 955 - Duration (s): 3.94
binding to core 0
binding to core 1
Run: Ops: 24 740 405 - Duration (s): 4.04
binding to core 0
binding to core 1
Run: Ops: 25 809 022 - Duration (s): 3.87
Throughput Test to run => OneToOneSequencedThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 1
Run: Ops: 26 274 607 - Duration (s): 3.81
binding to core 0
binding to core 1
Run: Ops: 26 022 874 - Duration (s): 3.84
binding to core 0
binding to core 1
Run: Ops: 26 299 504 - Duration (s): 3.8
binding to core 0
binding to core 1
Run: Ops: 26 385 377 - Duration (s): 3.79
binding to core 0
binding to core 1
Run: Ops: 25 239 631 - Duration (s): 3.96
binding to core 0
binding to core 1
Run: Ops: 25 675 246 - Duration (s): 3.89
binding to core 0
binding to core 1
Run: Ops: 24 881 737 - Duration (s): 4.02
Throughput Test to run => OneToOneTranslatorThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 1
Run: Ops: 34 150 812 - Duration (s): 2.93
binding to core 0
binding to core 1
Run: Ops: 33 925 583 - Duration (s): 2.95
binding to core 0
binding to core 1
Run: Ops: 30 175 971 - Duration (s): 3.31
binding to core 0
binding to core 1
Run: Ops: 29 556 801 - Duration (s): 3.38
binding to core 0
binding to core 1
Run: Ops: 29 388 772 - Duration (s): 3.4
binding to core 0
binding to core 1
Run: Ops: 30 020 591 - Duration (s): 3.33
binding to core 0
binding to core 1
Run: Ops: 26 044 644 - Duration (s): 3.84
Throughput Test to run => OneToThreeDiamondSequencedThroughputTest, Runs => 7
Starting throughput tests
Run: Ops: 27 306 117 - Duration (s): 3.66
Run: Ops: 27 145 108 - Duration (s): 3.68
Run: Ops: 27 395 488 - Duration (s): 3.65
Run: Ops: 27 217 238 - Duration (s): 3.67
Run: Ops: 27 143 398 - Duration (s): 3.68
Run: Ops: 27 363 853 - Duration (s): 3.65
Run: Ops: 27 408 576 - Duration (s): 3.65
Throughput Test to run => OneToThreePipelineSequencedThroughputTest, Runs => 7
Starting throughput tests
Run: Ops: 21 473 148 - Duration (s): 4.66
Run: Ops: 20 333 741 - Duration (s): 4.92
Run: Ops: 21 718 092 - Duration (s): 4.6
Run: Ops: 19 489 218 - Duration (s): 5.13
Run: Ops: 19 681 990 - Duration (s): 5.08
Run: Ops: 21 295 775 - Duration (s): 4.7
Run: Ops: 21 120 171 - Duration (s): 4.73
Throughput Test to run => OneToThreeReleasingWorkerPoolThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 2
binding to core 1
binding to core 3
Run: Ops: 9 969 016 - Duration (s): 1
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 9 985 032 - Duration (s): 1
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 9 764 852 - Duration (s): 1.02
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 9 791 298 - Duration (s): 1.02
binding to core 0
binding to core 3
binding to core 1
binding to core 2
Run: Ops: 9 882 711 - Duration (s): 1.01
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 9 861 398 - Duration (s): 1.01
binding to core 0
binding to core 3
binding to core 1
binding to core 2
Run: Ops: 9 806 536 - Duration (s): 1.02
Throughput Test to run => OneToThreeSequencedThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 50 621 018 - Duration (s): 5.93
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 51 340 149 - Duration (s): 5.84
binding to core 0
binding to core 2
binding to core 1
binding to core 3
Run: Ops: 50 389 079 - Duration (s): 5.95
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 51 258 183 - Duration (s): 5.85
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 51 126 922 - Duration (s): 5.87
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 50 920 645 - Duration (s): 5.89
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 52 591 572 - Duration (s): 5.7
Throughput Test to run => OneToThreeWorkerPoolThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 10 363 566 - Duration (s): 9.65
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 10 313 644 - Duration (s): 9.7
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 10 296 297 - Duration (s): 9.71
binding to core 0
binding to core 1
binding to core 2
binding to core 3
Run: Ops: 10 426 598 - Duration (s): 9.59
binding to core 0
binding to core 3
binding to core 1
binding to core 2
Run: Ops: 10 306 898 - Duration (s): 9.7
binding to core 0
binding to core 3
binding to core 1
binding to core 2
Run: Ops: 10 295 814 - Duration (s): 9.71
binding to core 0
binding to core 3
binding to core 1
binding to core 2
Run: Ops: 10 460 699 - Duration (s): 9.56
Throughput Test to run => ThreeToOneSequencedBatchThroughputTest, Runs => 7
Starting throughput tests
Run: Ops: 119 998 608 - Duration (ms): 833
Run: Ops: 121 027 718 - Duration (ms): 826
Run: Ops: 120 204 010 - Duration (ms): 832
Run: Ops: 120 438 685 - Duration (ms): 830
Run: Ops: 120 456 094 - Duration (ms): 830
Run: Ops: 119 930 536 - Duration (ms): 834
Run: Ops: 120 453 918 - Duration (ms): 830
Throughput Test to run => ThreeToOneSequencedThroughputTest, Runs => 7
Starting throughput tests
binding to core 0
binding to core 1
binding to core 2
binding to core 3
binding to core 4
Run: Ops: 3 416 279 - Duration (s): 5.85
binding to core 0
binding to core 1
binding to core 2
binding to core 3
binding to core 4
Run: Ops: 3 425 510 - Duration (s): 5.84
binding to core 0
binding to core 1
binding to core 2
binding to core 4
binding to core 3
Run: Ops: 3 392 300 - Duration (s): 5.9
binding to core 0
binding to core 1
binding to core 2
binding to core 4
binding to core 3
Run: Ops: 3 383 040 - Duration (s): 5.91
binding to core 0
binding to core 1
binding to core 2
binding to core 3
binding to core 4
Run: Ops: 3 488 598 - Duration (s): 5.73
binding to core 0
binding to core 2
binding to core 1
binding to core 3
binding to core 4
Run: Ops: 3 446 748 - Duration (s): 5.8
binding to core 0
binding to core 1
binding to core 2
binding to core 3
binding to core 4
Run: Ops: 3 386 453 - Duration (s): 5.91
Throughput Test to run => ThreeToThreeSequencedThroughputTest, Runs => 7
Starting throughput tests
Run: Ops: 508 944 223 - Duration (s): 1.06
Run: Ops: 511 072 286 - Duration (s): 1.06
Run: Ops: 529 820 037 - Duration (s): 1.02
Run: Ops: 532 306 048 - Duration (s): 1.01
Run: Ops: 530 170 115 - Duration (s): 1.02
Run: Ops: 513 763 632 - Duration (s): 1.05
Run: Ops: 517 745 238 - Duration (s): 1.04
Throughput Test to run => TwoToTwoWorkProcessorThroughputTest, Runs => 7
Starting throughput tests
Run: Ops: 5 508 974 - Duration (ms): 182
Run: Ops: 5 085 435 - Duration (ms): 197
Run: Ops: 5 408 796 - Duration (ms): 185
Run: Ops: 5 243 646 - Duration (ms): 191
Run: Ops: 5 428 881 - Duration (ms): 184
Run: Ops: 5 214 416 - Duration (ms): 192
Run: Ops: 5 473 783 - Duration (ms): 183
```