### PR TITLE
Fix #18: throw in MultiProducerSequencer::next(N) when N > bufferSize

### DIFF
--- a/Disruptor.Tests/SequencerTests.cpp
+++ b/Disruptor.Tests/SequencerTests.cpp
@@ -202,6 +202,11 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(ShouldNotAllowBulkNextOfZero, TSequencer, Seque
     BOOST_CHECK_THROW(this->m_sequencer->next(0), ArgumentException);
 }
 
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(ShouldNotAllowBulkNextGreaterThanBufferSize, TSequencer, Sequencers, SequencerTestFixture< TSequencer >)
+{
+    BOOST_CHECK_THROW(this->m_sequencer->next(this->m_bufferSize + 1), ArgumentException);
+}
+
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(ShouldNotAllowBulkTryNextLessThanZero, TSequencer, Sequencers, SequencerTestFixture< TSequencer >)
 {
     BOOST_CHECK_THROW(this->m_sequencer->tryNext(-1), ArgumentException);

--- a/Disruptor/MultiProducerSequencer.h
+++ b/Disruptor/MultiProducerSequencer.h
@@ -76,9 +76,9 @@ namespace Disruptor
          */ 
         std::int64_t next(std::int32_t n) override
         {
-            if (n < 1)
+            if (n < 1 || n > this->m_bufferSize)
             {
-                DISRUPTOR_THROW_ARGUMENT_EXCEPTION("n must be > 0");
+                DISRUPTOR_THROW_ARGUMENT_EXCEPTION("n must be > 0 and < bufferSize");
             }
 
             std::int64_t current;


### PR DESCRIPTION
Fixes #18.

Otherwise the producer can deadlock waiting for >N free slots that will never become available. This mirrors the equivalent fix already applied to `SingleProducerSequencer` in #10 and matches the upstream Java LMAX Disruptor behaviour.

## Changes
- `Disruptor/MultiProducerSequencer.h`: add `n > bufferSize` to the bounds check in `next(N)` and update the message to match `SingleProducerSequencer`.
- `Disruptor.Tests/SequencerTests.cpp`: add `ShouldNotAllowBulkNextGreaterThanBufferSize`. Because the test is templated on the existing `Sequencers` typedef, it covers both `MultiProducerSequencer` and `SingleProducerSequencer`.

## Notes
- I deliberately did not add the `n > bufferSize` check to either `tryNext(N)`, since the existing C++ `SingleProducerSequencer::tryNext` does not have it either; happy to extend if you would prefer strict Java parity.