### PR TITLE
Fix #17: aarch64 build (typo in BuildConfig.h)

### DIFF
--- a/Disruptor/BuildConfig.h
+++ b/Disruptor/BuildConfig.h
@@ -35,7 +35,7 @@
 # if __arm__
 #  define DISRUPTOR_CPU_ARM
 #  define DISRUPTOR_CPU_ARM_32
-# #elif __aarch64__
+# elif __aarch64__
 #  define DISRUPTOR_CPU_ARM
 #  define DISRUPTOR_CPU_ARM_64
 # elif __x86_64__ || __ppc64__


### PR DESCRIPTION
Fixes #17.

`BuildConfig.h` had a malformed `# #elif __aarch64__` directive (extra `#`). On aarch64 (Apple M1/M2, Linux ARM64) `__aarch64__` is defined but `__arm__` is not, so neither branch matched and `DISRUPTOR_CPU_ARM` was never defined. `SpinWait::yieldProcessor()` then fell through to the x86 `rep nop` assembly, which the assembler rejects with the "unknown mnemonic `rep`" error reported in the issue.

One-character fix: `# #elif __aarch64__` → `# elif __aarch64__`.

After this change, on aarch64 the preprocessor takes the `DISRUPTOR_CPU_ARM_64` branch and `SpinWait` emits the correct `yield` instruction