### PR TITLE
Add missing java v3.3.7 wait strategies: LiteBlocking, LiteTimeoutBlocking, PhasedBackoff

### DIFF
--- a/Disruptor.Tests/CMakeLists.txt
+++ b/Disruptor.Tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(DisruptorTests_sources
     IgnoreExceptionHandlerTests.cpp
     LifecycleAwareTests.cpp
     LiteBlockingWaitStrategyTests.cpp
+    LiteTimeoutBlockingWaitStrategyTests.cpp
     MultiProducerSequencerTests.cpp
     RingBufferTests.cpp
     RingBufferTestsFixture.cpp

--- a/Disruptor.Tests/CMakeLists.txt
+++ b/Disruptor.Tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(DisruptorTests_sources
     FixedSequenceGroupTest.cpp
     IgnoreExceptionHandlerTests.cpp
     LifecycleAwareTests.cpp
+    LiteBlockingWaitStrategyTests.cpp
     MultiProducerSequencerTests.cpp
     RingBufferTests.cpp
     RingBufferTestsFixture.cpp

--- a/Disruptor.Tests/CMakeLists.txt
+++ b/Disruptor.Tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(DisruptorTests_sources
     LiteBlockingWaitStrategyTests.cpp
     LiteTimeoutBlockingWaitStrategyTests.cpp
     MultiProducerSequencerTests.cpp
+    PhasedBackoffWaitStrategyTests.cpp
     RingBufferTests.cpp
     RingBufferTestsFixture.cpp
     RingBufferWithMocksTest.cpp

--- a/Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp
+++ b/Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp
@@ -1,0 +1,18 @@
+#include "stdafx.h"
+
+#include "Disruptor/LiteBlockingWaitStrategy.h"
+#include "WaitStrategyTestUtil.h"
+
+
+using namespace Disruptor;
+using namespace Disruptor::Tests;
+
+
+BOOST_AUTO_TEST_SUITE(LiteBlockingWaitStrategyTests)
+
+BOOST_AUTO_TEST_CASE(ShouldWaitForValue)
+{
+    assertWaitForWithDelayOf(50, std::make_shared< LiteBlockingWaitStrategy >());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp
+++ b/Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp
@@ -1,0 +1,44 @@
+#include "stdafx.h"
+
+#include "Disruptor/LiteTimeoutBlockingWaitStrategy.h"
+#include "Disruptor/Sequence.h"
+#include "Disruptor/TimeoutException.h"
+
+#include "SequenceBarrierMock.h"
+
+
+using namespace Disruptor;
+
+
+BOOST_AUTO_TEST_SUITE(LiteTimeoutBlockingWaitStrategyTest)
+
+BOOST_AUTO_TEST_CASE(ShouldTimeoutWaitFor)
+{
+    auto sequenceBarrierMock = std::make_shared< testing::NiceMock< Tests::SequenceBarrierMock > >();
+
+    auto theTimeout = std::chrono::milliseconds(500);
+    auto waitStrategy = std::make_shared< LiteTimeoutBlockingWaitStrategy >(theTimeout);
+    auto cursor = std::make_shared< Sequence >(5);
+    const auto& dependent = cursor;
+
+    EXPECT_CALL(*sequenceBarrierMock, checkAlert()).Times(testing::AtLeast(1));
+
+    auto t0 = ClockConfig::Clock::now();
+
+    try
+    {
+        waitStrategy->waitFor(6, *cursor, *dependent, *sequenceBarrierMock);
+        throw std::runtime_error("TimeoutException should have been thrown");
+    }
+    catch (TimeoutException&)
+    {
+    }
+
+    auto t1 = ClockConfig::Clock::now();
+
+    auto timeWaiting = t1 - t0;
+
+    BOOST_CHECK(timeWaiting >= theTimeout);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Disruptor.Tests/PhasedBackoffWaitStrategyTests.cpp
+++ b/Disruptor.Tests/PhasedBackoffWaitStrategyTests.cpp
@@ -1,0 +1,41 @@
+#include "stdafx.h"
+
+#include "Disruptor/PhasedBackoffWaitStrategy.h"
+#include "WaitStrategyTestUtil.h"
+
+
+using namespace Disruptor;
+using namespace Disruptor::Tests;
+
+
+BOOST_AUTO_TEST_SUITE(PhasedBackoffWaitStrategyTests)
+
+BOOST_AUTO_TEST_CASE(ShouldHandleImmediateSequenceChange)
+{
+    assertWaitForWithDelayOf(0, PhasedBackoffWaitStrategy::withLock(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+    assertWaitForWithDelayOf(0, PhasedBackoffWaitStrategy::withLiteLock(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+    assertWaitForWithDelayOf(0, PhasedBackoffWaitStrategy::withSleep(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+}
+
+BOOST_AUTO_TEST_CASE(ShouldHandleSequenceChangeWithOneMillisecondDelay)
+{
+    assertWaitForWithDelayOf(1, PhasedBackoffWaitStrategy::withLock(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+    assertWaitForWithDelayOf(1, PhasedBackoffWaitStrategy::withLiteLock(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+    assertWaitForWithDelayOf(1, PhasedBackoffWaitStrategy::withSleep(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+}
+
+BOOST_AUTO_TEST_CASE(ShouldHandleSequenceChangeWithTwoMillisecondDelay)
+{
+    assertWaitForWithDelayOf(2, PhasedBackoffWaitStrategy::withLock(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+    assertWaitForWithDelayOf(2, PhasedBackoffWaitStrategy::withLiteLock(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+    assertWaitForWithDelayOf(2, PhasedBackoffWaitStrategy::withSleep(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+}
+
+BOOST_AUTO_TEST_CASE(ShouldHandleSequenceChangeWithTenMillisecondDelay)
+{
+    assertWaitForWithDelayOf(10, PhasedBackoffWaitStrategy::withLock(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+    assertWaitForWithDelayOf(10, PhasedBackoffWaitStrategy::withLiteLock(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+    assertWaitForWithDelayOf(10, PhasedBackoffWaitStrategy::withSleep(std::chrono::milliseconds(1), std::chrono::milliseconds(1)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Disruptor/CMakeLists.txt
+++ b/Disruptor/CMakeLists.txt
@@ -16,6 +16,7 @@ set(Disruptor_sources
     BlockingWaitStrategy.cpp
     BusySpinWaitStrategy.cpp
     FixedSequenceGroup.cpp
+    LiteBlockingWaitStrategy.cpp
     ProcessingSequenceBarrier.cpp
     ProducerType.cpp
     RoundRobinThreadAffinedTaskScheduler.cpp
@@ -88,6 +89,7 @@ set(Disruptor_headers
     ITimeoutHandler.h
     IWaitStrategy.h
     IWorkHandler.h
+    LiteBlockingWaitStrategy.h
     MultiProducerSequencer.h
     NoOpEventProcessor.h
     NotSupportedException.h

--- a/Disruptor/CMakeLists.txt
+++ b/Disruptor/CMakeLists.txt
@@ -17,6 +17,7 @@ set(Disruptor_sources
     BusySpinWaitStrategy.cpp
     FixedSequenceGroup.cpp
     LiteBlockingWaitStrategy.cpp
+    LiteTimeoutBlockingWaitStrategy.cpp
     ProcessingSequenceBarrier.cpp
     ProducerType.cpp
     RoundRobinThreadAffinedTaskScheduler.cpp
@@ -90,6 +91,7 @@ set(Disruptor_headers
     IWaitStrategy.h
     IWorkHandler.h
     LiteBlockingWaitStrategy.h
+    LiteTimeoutBlockingWaitStrategy.h
     MultiProducerSequencer.h
     NoOpEventProcessor.h
     NotSupportedException.h

--- a/Disruptor/CMakeLists.txt
+++ b/Disruptor/CMakeLists.txt
@@ -18,6 +18,7 @@ set(Disruptor_sources
     FixedSequenceGroup.cpp
     LiteBlockingWaitStrategy.cpp
     LiteTimeoutBlockingWaitStrategy.cpp
+    PhasedBackoffWaitStrategy.cpp
     ProcessingSequenceBarrier.cpp
     ProducerType.cpp
     RoundRobinThreadAffinedTaskScheduler.cpp
@@ -95,6 +96,7 @@ set(Disruptor_headers
     MultiProducerSequencer.h
     NoOpEventProcessor.h
     NotSupportedException.h
+    PhasedBackoffWaitStrategy.h
     Pragmas.h
     ProcessingSequenceBarrier.h
     ProducerType.h

--- a/Disruptor/LiteBlockingWaitStrategy.cpp
+++ b/Disruptor/LiteBlockingWaitStrategy.cpp
@@ -1,0 +1,60 @@
+#include "stdafx.h"
+#include "LiteBlockingWaitStrategy.h"
+
+#include <ostream>
+
+#include "ISequenceBarrier.h"
+#include "Sequence.h"
+
+
+namespace Disruptor
+{
+
+    std::int64_t LiteBlockingWaitStrategy::waitFor(std::int64_t sequence,
+                                                   Sequence& cursor,
+                                                   ISequence& dependentSequence,
+                                                   ISequenceBarrier& barrier)
+    {
+        if (cursor.value() < sequence)
+        {
+            boost::unique_lock< decltype(m_gate) > uniqueLock(m_gate);
+
+            do
+            {
+                m_signalNeeded.exchange(true);
+
+                if (cursor.value() >= sequence)
+                    break;
+
+                barrier.checkAlert();
+
+                m_conditionVariable.wait(uniqueLock);
+            }
+            while (cursor.value() < sequence);
+        }
+
+        std::int64_t availableSequence;
+        while ((availableSequence = dependentSequence.value()) < sequence)
+        {
+            barrier.checkAlert();
+        }
+
+        return availableSequence;
+    }
+
+    void LiteBlockingWaitStrategy::signalAllWhenBlocking()
+    {
+        if (m_signalNeeded.exchange(false))
+        {
+            boost::unique_lock< decltype(m_gate) > uniqueLock(m_gate);
+
+            m_conditionVariable.notify_all();
+        }
+    }
+
+    void LiteBlockingWaitStrategy::writeDescriptionTo(std::ostream& stream) const
+    {
+        stream << "LiteBlockingWaitStrategy";
+    }
+
+} // namespace Disruptor

--- a/Disruptor/LiteBlockingWaitStrategy.h
+++ b/Disruptor/LiteBlockingWaitStrategy.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <atomic>
+
+#include <boost/thread.hpp>
+
+#include "Disruptor/IWaitStrategy.h"
+
+
+namespace Disruptor
+{
+
+    /**
+     * Variation of the BlockingWaitStrategy that attempts to elide conditional wake-ups when the lock is uncontended.
+     * Shows performance improvements on microbenchmarks. However this wait strategy should be considered experimental
+     * as the correctness of the lock elision code has not been fully proved.
+     */
+    class LiteBlockingWaitStrategy : public IWaitStrategy
+    {
+    public:
+        /**
+         * \see IWaitStrategy::waitFor
+         */
+        std::int64_t waitFor(std::int64_t sequence,
+                             Sequence& cursor,
+                             ISequence& dependentSequence,
+                             ISequenceBarrier& barrier) override;
+
+        /**
+         * \see IWaitStrategy::signalAllWhenBlocking
+         */
+        void signalAllWhenBlocking() override;
+
+        void writeDescriptionTo(std::ostream& stream) const override;
+
+    private:
+        boost::recursive_mutex m_gate;
+        boost::condition_variable_any m_conditionVariable;
+        std::atomic< bool > m_signalNeeded{ false };
+    };
+
+} // namespace Disruptor

--- a/Disruptor/LiteTimeoutBlockingWaitStrategy.cpp
+++ b/Disruptor/LiteTimeoutBlockingWaitStrategy.cpp
@@ -1,0 +1,67 @@
+#include "stdafx.h"
+#include "LiteTimeoutBlockingWaitStrategy.h"
+
+#include <ostream>
+
+#include <boost/chrono.hpp>
+
+#include "ISequenceBarrier.h"
+#include "Sequence.h"
+#include "TimeoutException.h"
+
+
+namespace Disruptor
+{
+
+    LiteTimeoutBlockingWaitStrategy::LiteTimeoutBlockingWaitStrategy(ClockConfig::Duration timeout)
+        : m_timeout(timeout)
+    {
+    }
+
+    std::int64_t LiteTimeoutBlockingWaitStrategy::waitFor(std::int64_t sequence,
+                                                          Sequence& cursor,
+                                                          ISequence& dependentSequence,
+                                                          ISequenceBarrier& barrier)
+    {
+        auto timeSpan = boost::chrono::microseconds(std::chrono::duration_cast< std::chrono::microseconds >(m_timeout).count());
+
+        if (cursor.value() < sequence)
+        {
+            boost::unique_lock< decltype(m_gate) > uniqueLock(m_gate);
+
+            while (cursor.value() < sequence)
+            {
+                m_signalNeeded.exchange(true);
+
+                barrier.checkAlert();
+
+                if (m_conditionVariable.wait_for(uniqueLock, timeSpan) == boost::cv_status::timeout)
+                    DISRUPTOR_THROW_TIMEOUT_EXCEPTION();
+            }
+        }
+
+        std::int64_t availableSequence;
+        while ((availableSequence = dependentSequence.value()) < sequence)
+        {
+            barrier.checkAlert();
+        }
+
+        return availableSequence;
+    }
+
+    void LiteTimeoutBlockingWaitStrategy::signalAllWhenBlocking()
+    {
+        if (m_signalNeeded.exchange(false))
+        {
+            boost::unique_lock< decltype(m_gate) > uniqueLock(m_gate);
+
+            m_conditionVariable.notify_all();
+        }
+    }
+
+    void LiteTimeoutBlockingWaitStrategy::writeDescriptionTo(std::ostream& stream) const
+    {
+        stream << "LiteTimeoutBlockingWaitStrategy";
+    }
+
+} // namespace Disruptor

--- a/Disruptor/LiteTimeoutBlockingWaitStrategy.h
+++ b/Disruptor/LiteTimeoutBlockingWaitStrategy.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <atomic>
+
+#include <boost/thread.hpp>
+
+#include "Disruptor/ClockConfig.h"
+#include "Disruptor/IWaitStrategy.h"
+
+
+namespace Disruptor
+{
+
+    /**
+     * Variation of the TimeoutBlockingWaitStrategy that attempts to elide conditional wake-ups
+     * when the lock is uncontended.
+     */
+    class LiteTimeoutBlockingWaitStrategy : public IWaitStrategy
+    {
+    public:
+        explicit LiteTimeoutBlockingWaitStrategy(ClockConfig::Duration timeout);
+
+        /**
+         * \see IWaitStrategy::waitFor
+         */
+        std::int64_t waitFor(std::int64_t sequence,
+                             Sequence& cursor,
+                             ISequence& dependentSequence,
+                             ISequenceBarrier& barrier) override;
+
+        /**
+         * \see IWaitStrategy::signalAllWhenBlocking
+         */
+        void signalAllWhenBlocking() override;
+
+        void writeDescriptionTo(std::ostream& stream) const override;
+
+    private:
+        ClockConfig::Duration m_timeout;
+        boost::recursive_mutex m_gate;
+        boost::condition_variable_any m_conditionVariable;
+        std::atomic< bool > m_signalNeeded{ false };
+    };
+
+} // namespace Disruptor

--- a/Disruptor/PhasedBackoffWaitStrategy.cpp
+++ b/Disruptor/PhasedBackoffWaitStrategy.cpp
@@ -1,0 +1,95 @@
+#include "stdafx.h"
+#include "PhasedBackoffWaitStrategy.h"
+
+#include <ostream>
+#include <thread>
+
+#include "ArgumentNullException.h"
+#include "BlockingWaitStrategy.h"
+#include "LiteBlockingWaitStrategy.h"
+#include "SleepingWaitStrategy.h"
+
+
+namespace Disruptor
+{
+
+    PhasedBackoffWaitStrategy::PhasedBackoffWaitStrategy(ClockConfig::Duration spinTimeout,
+                                                         ClockConfig::Duration yieldTimeout,
+                                                         const std::shared_ptr< IWaitStrategy >& fallbackStrategy)
+        : m_spinTimeout(spinTimeout)
+        , m_yieldTimeout(spinTimeout + yieldTimeout)
+        , m_fallbackStrategy(fallbackStrategy)
+    {
+        if (fallbackStrategy == nullptr)
+            DISRUPTOR_THROW_ARGUMENT_NULL_EXCEPTION(fallbackStrategy);
+    }
+
+    std::shared_ptr< PhasedBackoffWaitStrategy > PhasedBackoffWaitStrategy::withLock(ClockConfig::Duration spinTimeout,
+                                                                                     ClockConfig::Duration yieldTimeout)
+    {
+        return std::make_shared< PhasedBackoffWaitStrategy >(spinTimeout, yieldTimeout, std::make_shared< BlockingWaitStrategy >());
+    }
+
+    std::shared_ptr< PhasedBackoffWaitStrategy > PhasedBackoffWaitStrategy::withLiteLock(ClockConfig::Duration spinTimeout,
+                                                                                         ClockConfig::Duration yieldTimeout)
+    {
+        return std::make_shared< PhasedBackoffWaitStrategy >(spinTimeout, yieldTimeout, std::make_shared< LiteBlockingWaitStrategy >());
+    }
+
+    std::shared_ptr< PhasedBackoffWaitStrategy > PhasedBackoffWaitStrategy::withSleep(ClockConfig::Duration spinTimeout,
+                                                                                      ClockConfig::Duration yieldTimeout)
+    {
+        return std::make_shared< PhasedBackoffWaitStrategy >(spinTimeout, yieldTimeout, std::make_shared< SleepingWaitStrategy >(0));
+    }
+
+    std::int64_t PhasedBackoffWaitStrategy::waitFor(std::int64_t sequence,
+                                                    Sequence& cursor,
+                                                    ISequence& dependentSequence,
+                                                    ISequenceBarrier& barrier)
+    {
+        std::int64_t availableSequence;
+        ClockConfig::TimePoint startTime;
+        auto startTimeSet = false;
+        auto counter = m_spinTries;
+
+        do
+        {
+            if ((availableSequence = dependentSequence.value()) >= sequence)
+                return availableSequence;
+
+            if (--counter == 0)
+            {
+                if (!startTimeSet)
+                {
+                    startTime = ClockConfig::Clock::now();
+                    startTimeSet = true;
+                }
+                else
+                {
+                    auto timeDelta = ClockConfig::Clock::now() - startTime;
+                    if (timeDelta > m_yieldTimeout)
+                        return m_fallbackStrategy->waitFor(sequence, cursor, dependentSequence, barrier);
+
+                    if (timeDelta > m_spinTimeout)
+                        std::this_thread::yield();
+                }
+
+                counter = m_spinTries;
+            }
+        }
+        while (true);
+    }
+
+    void PhasedBackoffWaitStrategy::signalAllWhenBlocking()
+    {
+        m_fallbackStrategy->signalAllWhenBlocking();
+    }
+
+    void PhasedBackoffWaitStrategy::writeDescriptionTo(std::ostream& stream) const
+    {
+        stream << "PhasedBackoffWaitStrategy (fallback: ";
+        m_fallbackStrategy->writeDescriptionTo(stream);
+        stream << ")";
+    }
+
+} // namespace Disruptor

--- a/Disruptor/PhasedBackoffWaitStrategy.h
+++ b/Disruptor/PhasedBackoffWaitStrategy.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <memory>
+
+#include "Disruptor/ClockConfig.h"
+#include "Disruptor/IWaitStrategy.h"
+
+
+namespace Disruptor
+{
+
+    /**
+     * Phased wait strategy for waiting IEventProcessors on a barrier.
+     * Spins, then yields, then waits using the configured fallback IWaitStrategy.
+     * This strategy can be used when throughput and low-latency are not as important as CPU resource.
+     */
+    class PhasedBackoffWaitStrategy : public IWaitStrategy
+    {
+    public:
+        PhasedBackoffWaitStrategy(ClockConfig::Duration spinTimeout,
+                                  ClockConfig::Duration yieldTimeout,
+                                  const std::shared_ptr< IWaitStrategy >& fallbackStrategy);
+
+        /**
+         * Construct PhasedBackoffWaitStrategy with fallback to BlockingWaitStrategy.
+         *
+         * \param spinTimeout The maximum time in to busy spin for.
+         * \param yieldTimeout The maximum time in to yield for.
+         * \returns The constructed wait strategy.
+         */
+        static std::shared_ptr< PhasedBackoffWaitStrategy > withLock(ClockConfig::Duration spinTimeout, ClockConfig::Duration yieldTimeout);
+
+        /**
+         * Construct PhasedBackoffWaitStrategy with fallback to LiteBlockingWaitStrategy.
+         *
+         * \param spinTimeout The maximum time in to busy spin for.
+         * \param yieldTimeout The maximum time in to yield for.
+         * \returns The constructed wait strategy.
+         */
+        static std::shared_ptr< PhasedBackoffWaitStrategy > withLiteLock(ClockConfig::Duration spinTimeout, ClockConfig::Duration yieldTimeout);
+
+        /**
+         * Construct PhasedBackoffWaitStrategy with fallback to SleepingWaitStrategy.
+         *
+         * \param spinTimeout The maximum time in to busy spin for.
+         * \param yieldTimeout The maximum time in to yield for.
+         * \returns The constructed wait strategy.
+         */
+        static std::shared_ptr< PhasedBackoffWaitStrategy > withSleep(ClockConfig::Duration spinTimeout, ClockConfig::Duration yieldTimeout);
+
+        /**
+         * \see IWaitStrategy::waitFor
+         */
+        std::int64_t waitFor(std::int64_t sequence,
+                             Sequence& cursor,
+                             ISequence& dependentSequence,
+                             ISequenceBarrier& barrier) override;
+
+        /**
+         * \see IWaitStrategy::signalAllWhenBlocking
+         */
+        void signalAllWhenBlocking() override;
+
+        void writeDescriptionTo(std::ostream& stream) const override;
+
+    private:
+        const std::int32_t m_spinTries = 10000;
+        ClockConfig::Duration m_spinTimeout;
+        ClockConfig::Duration m_yieldTimeout;
+        std::shared_ptr< IWaitStrategy > m_fallbackStrategy;
+    };
+
+} // namespace Disruptor

--- a/msvc/2015/Disruptor.Tests.vcxproj
+++ b/msvc/2015/Disruptor.Tests.vcxproj
@@ -163,6 +163,7 @@
     <ClCompile Include="../../Disruptor.Tests/BatchEventProcessorTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/IgnoreExceptionHandlerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LifecycleAwareTests.cpp" />
+    <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/MultiProducerSequencerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTestsFixture.cpp" />

--- a/msvc/2015/Disruptor.Tests.vcxproj
+++ b/msvc/2015/Disruptor.Tests.vcxproj
@@ -166,6 +166,7 @@
     <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/MultiProducerSequencerTests.cpp" />
+    <ClCompile Include="../../Disruptor.Tests/PhasedBackoffWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTestsFixture.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferWithMocksTest.cpp" />

--- a/msvc/2015/Disruptor.Tests.vcxproj
+++ b/msvc/2015/Disruptor.Tests.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="../../Disruptor.Tests/IgnoreExceptionHandlerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LifecycleAwareTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp" />
+    <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/MultiProducerSequencerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTestsFixture.cpp" />

--- a/msvc/2015/Disruptor.Tests.vcxproj.filters
+++ b/msvc/2015/Disruptor.Tests.vcxproj.filters
@@ -214,6 +214,9 @@
     <ClCompile Include="../../Disruptor.Tests/TimeoutBlockingWaitStrategyTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="../../Disruptor.Tests/DelayedEventHandler.cpp">
       <Filter>Tests\Dsl\Stubs</Filter>
     </ClCompile>

--- a/msvc/2015/Disruptor.Tests.vcxproj.filters
+++ b/msvc/2015/Disruptor.Tests.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="../../Disruptor.Tests/DelayedEventHandler.cpp">
       <Filter>Tests\Dsl\Stubs</Filter>
     </ClCompile>

--- a/msvc/2015/Disruptor.Tests.vcxproj.filters
+++ b/msvc/2015/Disruptor.Tests.vcxproj.filters
@@ -220,6 +220,9 @@
     <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="../../Disruptor.Tests/PhasedBackoffWaitStrategyTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="../../Disruptor.Tests/DelayedEventHandler.cpp">
       <Filter>Tests\Dsl\Stubs</Filter>
     </ClCompile>

--- a/msvc/2015/Disruptor.vcxproj
+++ b/msvc/2015/Disruptor.vcxproj
@@ -141,6 +141,7 @@
     <ClInclude Include="../../Disruptor/IWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IWorkHandler.h" />
     <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/MultiProducerSequencer.h" />
     <ClInclude Include="../../Disruptor/NoOpEventProcessor.h" />
     <ClInclude Include="../../Disruptor/NotSupportedException.h" />
@@ -175,6 +176,7 @@
     <ClCompile Include="../../Disruptor/BusySpinWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/ProducerType.cpp" />
     <ClCompile Include="../../Disruptor/RoundRobinThreadAffinedTaskScheduler.cpp" />

--- a/msvc/2015/Disruptor.vcxproj
+++ b/msvc/2015/Disruptor.vcxproj
@@ -145,6 +145,7 @@
     <ClInclude Include="../../Disruptor/MultiProducerSequencer.h" />
     <ClInclude Include="../../Disruptor/NoOpEventProcessor.h" />
     <ClInclude Include="../../Disruptor/NotSupportedException.h" />
+    <ClInclude Include="../../Disruptor/PhasedBackoffWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/Pragmas.h" />
     <ClInclude Include="../../Disruptor/ProcessingSequenceBarrier.h" />
     <ClInclude Include="../../Disruptor/ProducerType.h" />
@@ -177,6 +178,7 @@
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/PhasedBackoffWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/ProducerType.cpp" />
     <ClCompile Include="../../Disruptor/RoundRobinThreadAffinedTaskScheduler.cpp" />

--- a/msvc/2015/Disruptor.vcxproj
+++ b/msvc/2015/Disruptor.vcxproj
@@ -140,6 +140,7 @@
     <ClInclude Include="../../Disruptor/ITimeoutHandler.h" />
     <ClInclude Include="../../Disruptor/IWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IWorkHandler.h" />
+    <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/MultiProducerSequencer.h" />
     <ClInclude Include="../../Disruptor/NoOpEventProcessor.h" />
     <ClInclude Include="../../Disruptor/NotSupportedException.h" />
@@ -173,6 +174,7 @@
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/BusySpinWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
+    <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/ProducerType.cpp" />
     <ClCompile Include="../../Disruptor/RoundRobinThreadAffinedTaskScheduler.cpp" />

--- a/msvc/2015/Disruptor.vcxproj.filters
+++ b/msvc/2015/Disruptor.vcxproj.filters
@@ -155,6 +155,7 @@
     <ClInclude Include="../../Disruptor/SpinWaitWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/TimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IEventReleaseAware.h" />
     <ClInclude Include="../../Disruptor/IEventReleaser.h" />
     <ClInclude Include="../../Disruptor/ThreadPerTaskScheduler.h">
@@ -183,6 +184,7 @@
     <ClCompile Include="../../Disruptor/Sequence.cpp" />
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/YieldingWaitStrategy.cpp" />

--- a/msvc/2015/Disruptor.vcxproj.filters
+++ b/msvc/2015/Disruptor.vcxproj.filters
@@ -154,6 +154,7 @@
     <ClInclude Include="../../Disruptor/IgnoreExceptionHandler.h" />
     <ClInclude Include="../../Disruptor/SpinWaitWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/TimeoutBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IEventReleaseAware.h" />
     <ClInclude Include="../../Disruptor/IEventReleaser.h" />
     <ClInclude Include="../../Disruptor/ThreadPerTaskScheduler.h">
@@ -181,6 +182,7 @@
     </ClCompile>
     <ClCompile Include="../../Disruptor/Sequence.cpp" />
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/YieldingWaitStrategy.cpp" />

--- a/msvc/2015/Disruptor.vcxproj.filters
+++ b/msvc/2015/Disruptor.vcxproj.filters
@@ -156,6 +156,7 @@
     <ClInclude Include="../../Disruptor/TimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/PhasedBackoffWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IEventReleaseAware.h" />
     <ClInclude Include="../../Disruptor/IEventReleaser.h" />
     <ClInclude Include="../../Disruptor/ThreadPerTaskScheduler.h">
@@ -185,6 +186,7 @@
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/PhasedBackoffWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/YieldingWaitStrategy.cpp" />

--- a/msvc/2017/Disruptor.Tests.vcxproj
+++ b/msvc/2017/Disruptor.Tests.vcxproj
@@ -163,6 +163,7 @@
     <ClCompile Include="../../Disruptor.Tests/BatchEventProcessorTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/IgnoreExceptionHandlerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LifecycleAwareTests.cpp" />
+    <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/MultiProducerSequencerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTestsFixture.cpp" />

--- a/msvc/2017/Disruptor.Tests.vcxproj
+++ b/msvc/2017/Disruptor.Tests.vcxproj
@@ -166,6 +166,7 @@
     <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/MultiProducerSequencerTests.cpp" />
+    <ClCompile Include="../../Disruptor.Tests/PhasedBackoffWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTestsFixture.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferWithMocksTest.cpp" />

--- a/msvc/2017/Disruptor.Tests.vcxproj
+++ b/msvc/2017/Disruptor.Tests.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="../../Disruptor.Tests/IgnoreExceptionHandlerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LifecycleAwareTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp" />
+    <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/MultiProducerSequencerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTestsFixture.cpp" />

--- a/msvc/2017/Disruptor.Tests.vcxproj.filters
+++ b/msvc/2017/Disruptor.Tests.vcxproj.filters
@@ -214,6 +214,9 @@
     <ClCompile Include="../../Disruptor.Tests/TimeoutBlockingWaitStrategyTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="../../Disruptor.Tests/DelayedEventHandler.cpp">
       <Filter>Tests\Dsl\Stubs</Filter>
     </ClCompile>

--- a/msvc/2017/Disruptor.Tests.vcxproj.filters
+++ b/msvc/2017/Disruptor.Tests.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="../../Disruptor.Tests/DelayedEventHandler.cpp">
       <Filter>Tests\Dsl\Stubs</Filter>
     </ClCompile>

--- a/msvc/2017/Disruptor.Tests.vcxproj.filters
+++ b/msvc/2017/Disruptor.Tests.vcxproj.filters
@@ -220,6 +220,9 @@
     <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="../../Disruptor.Tests/PhasedBackoffWaitStrategyTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="../../Disruptor.Tests/DelayedEventHandler.cpp">
       <Filter>Tests\Dsl\Stubs</Filter>
     </ClCompile>

--- a/msvc/2017/Disruptor.vcxproj
+++ b/msvc/2017/Disruptor.vcxproj
@@ -141,6 +141,7 @@
     <ClInclude Include="../../Disruptor/IWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IWorkHandler.h" />
     <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/MultiProducerSequencer.h" />
     <ClInclude Include="../../Disruptor/NoOpEventProcessor.h" />
     <ClInclude Include="../../Disruptor/NotSupportedException.h" />
@@ -175,6 +176,7 @@
     <ClCompile Include="../../Disruptor/BusySpinWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/ProducerType.cpp" />
     <ClCompile Include="../../Disruptor/RoundRobinThreadAffinedTaskScheduler.cpp" />

--- a/msvc/2017/Disruptor.vcxproj
+++ b/msvc/2017/Disruptor.vcxproj
@@ -145,6 +145,7 @@
     <ClInclude Include="../../Disruptor/MultiProducerSequencer.h" />
     <ClInclude Include="../../Disruptor/NoOpEventProcessor.h" />
     <ClInclude Include="../../Disruptor/NotSupportedException.h" />
+    <ClInclude Include="../../Disruptor/PhasedBackoffWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/Pragmas.h" />
     <ClInclude Include="../../Disruptor/ProcessingSequenceBarrier.h" />
     <ClInclude Include="../../Disruptor/ProducerType.h" />
@@ -177,6 +178,7 @@
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/PhasedBackoffWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/ProducerType.cpp" />
     <ClCompile Include="../../Disruptor/RoundRobinThreadAffinedTaskScheduler.cpp" />

--- a/msvc/2017/Disruptor.vcxproj
+++ b/msvc/2017/Disruptor.vcxproj
@@ -140,6 +140,7 @@
     <ClInclude Include="../../Disruptor/ITimeoutHandler.h" />
     <ClInclude Include="../../Disruptor/IWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IWorkHandler.h" />
+    <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/MultiProducerSequencer.h" />
     <ClInclude Include="../../Disruptor/NoOpEventProcessor.h" />
     <ClInclude Include="../../Disruptor/NotSupportedException.h" />
@@ -173,6 +174,7 @@
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/BusySpinWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
+    <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/ProducerType.cpp" />
     <ClCompile Include="../../Disruptor/RoundRobinThreadAffinedTaskScheduler.cpp" />

--- a/msvc/2017/Disruptor.vcxproj.filters
+++ b/msvc/2017/Disruptor.vcxproj.filters
@@ -155,6 +155,7 @@
     <ClInclude Include="../../Disruptor/SpinWaitWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/TimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IEventReleaseAware.h" />
     <ClInclude Include="../../Disruptor/IEventReleaser.h" />
     <ClInclude Include="../../Disruptor/ThreadPerTaskScheduler.h">
@@ -183,6 +184,7 @@
     <ClCompile Include="../../Disruptor/Sequence.cpp" />
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/YieldingWaitStrategy.cpp" />

--- a/msvc/2017/Disruptor.vcxproj.filters
+++ b/msvc/2017/Disruptor.vcxproj.filters
@@ -154,6 +154,7 @@
     <ClInclude Include="../../Disruptor/IgnoreExceptionHandler.h" />
     <ClInclude Include="../../Disruptor/SpinWaitWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/TimeoutBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IEventReleaseAware.h" />
     <ClInclude Include="../../Disruptor/IEventReleaser.h" />
     <ClInclude Include="../../Disruptor/ThreadPerTaskScheduler.h">
@@ -181,6 +182,7 @@
     </ClCompile>
     <ClCompile Include="../../Disruptor/Sequence.cpp" />
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/YieldingWaitStrategy.cpp" />

--- a/msvc/2017/Disruptor.vcxproj.filters
+++ b/msvc/2017/Disruptor.vcxproj.filters
@@ -156,6 +156,7 @@
     <ClInclude Include="../../Disruptor/TimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/PhasedBackoffWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IEventReleaseAware.h" />
     <ClInclude Include="../../Disruptor/IEventReleaser.h" />
     <ClInclude Include="../../Disruptor/ThreadPerTaskScheduler.h">
@@ -185,6 +186,7 @@
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/PhasedBackoffWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/YieldingWaitStrategy.cpp" />

--- a/msvc/2019/Disruptor.Tests.vcxproj
+++ b/msvc/2019/Disruptor.Tests.vcxproj
@@ -163,6 +163,7 @@
     <ClCompile Include="../../Disruptor.Tests/BatchEventProcessorTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/IgnoreExceptionHandlerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LifecycleAwareTests.cpp" />
+    <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/MultiProducerSequencerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTestsFixture.cpp" />

--- a/msvc/2019/Disruptor.Tests.vcxproj
+++ b/msvc/2019/Disruptor.Tests.vcxproj
@@ -166,6 +166,7 @@
     <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/MultiProducerSequencerTests.cpp" />
+    <ClCompile Include="../../Disruptor.Tests/PhasedBackoffWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTestsFixture.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferWithMocksTest.cpp" />

--- a/msvc/2019/Disruptor.Tests.vcxproj
+++ b/msvc/2019/Disruptor.Tests.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="../../Disruptor.Tests/IgnoreExceptionHandlerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LifecycleAwareTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp" />
+    <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/MultiProducerSequencerTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTests.cpp" />
     <ClCompile Include="../../Disruptor.Tests/RingBufferTestsFixture.cpp" />

--- a/msvc/2019/Disruptor.Tests.vcxproj.filters
+++ b/msvc/2019/Disruptor.Tests.vcxproj.filters
@@ -214,6 +214,9 @@
     <ClCompile Include="../../Disruptor.Tests/TimeoutBlockingWaitStrategyTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="../../Disruptor.Tests/DelayedEventHandler.cpp">
       <Filter>Tests\Dsl\Stubs</Filter>
     </ClCompile>

--- a/msvc/2019/Disruptor.Tests.vcxproj.filters
+++ b/msvc/2019/Disruptor.Tests.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="../../Disruptor.Tests/LiteBlockingWaitStrategyTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="../../Disruptor.Tests/DelayedEventHandler.cpp">
       <Filter>Tests\Dsl\Stubs</Filter>
     </ClCompile>

--- a/msvc/2019/Disruptor.Tests.vcxproj.filters
+++ b/msvc/2019/Disruptor.Tests.vcxproj.filters
@@ -220,6 +220,9 @@
     <ClCompile Include="../../Disruptor.Tests/LiteTimeoutBlockingWaitStrategyTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="../../Disruptor.Tests/PhasedBackoffWaitStrategyTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
     <ClCompile Include="../../Disruptor.Tests/DelayedEventHandler.cpp">
       <Filter>Tests\Dsl\Stubs</Filter>
     </ClCompile>

--- a/msvc/2019/Disruptor.vcxproj
+++ b/msvc/2019/Disruptor.vcxproj
@@ -141,6 +141,7 @@
     <ClInclude Include="../../Disruptor/IWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IWorkHandler.h" />
     <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/MultiProducerSequencer.h" />
     <ClInclude Include="../../Disruptor/NoOpEventProcessor.h" />
     <ClInclude Include="../../Disruptor/NotSupportedException.h" />
@@ -175,6 +176,7 @@
     <ClCompile Include="../../Disruptor/BusySpinWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/ProducerType.cpp" />
     <ClCompile Include="../../Disruptor/RoundRobinThreadAffinedTaskScheduler.cpp" />

--- a/msvc/2019/Disruptor.vcxproj
+++ b/msvc/2019/Disruptor.vcxproj
@@ -145,6 +145,7 @@
     <ClInclude Include="../../Disruptor/MultiProducerSequencer.h" />
     <ClInclude Include="../../Disruptor/NoOpEventProcessor.h" />
     <ClInclude Include="../../Disruptor/NotSupportedException.h" />
+    <ClInclude Include="../../Disruptor/PhasedBackoffWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/Pragmas.h" />
     <ClInclude Include="../../Disruptor/ProcessingSequenceBarrier.h" />
     <ClInclude Include="../../Disruptor/ProducerType.h" />
@@ -177,6 +178,7 @@
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/PhasedBackoffWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/ProducerType.cpp" />
     <ClCompile Include="../../Disruptor/RoundRobinThreadAffinedTaskScheduler.cpp" />

--- a/msvc/2019/Disruptor.vcxproj
+++ b/msvc/2019/Disruptor.vcxproj
@@ -140,6 +140,7 @@
     <ClInclude Include="../../Disruptor/ITimeoutHandler.h" />
     <ClInclude Include="../../Disruptor/IWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IWorkHandler.h" />
+    <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/MultiProducerSequencer.h" />
     <ClInclude Include="../../Disruptor/NoOpEventProcessor.h" />
     <ClInclude Include="../../Disruptor/NotSupportedException.h" />
@@ -173,6 +174,7 @@
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/BusySpinWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
+    <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/ProducerType.cpp" />
     <ClCompile Include="../../Disruptor/RoundRobinThreadAffinedTaskScheduler.cpp" />

--- a/msvc/2019/Disruptor.vcxproj.filters
+++ b/msvc/2019/Disruptor.vcxproj.filters
@@ -155,6 +155,7 @@
     <ClInclude Include="../../Disruptor/SpinWaitWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/TimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IEventReleaseAware.h" />
     <ClInclude Include="../../Disruptor/IEventReleaser.h" />
     <ClInclude Include="../../Disruptor/ThreadPerTaskScheduler.h">
@@ -183,6 +184,7 @@
     <ClCompile Include="../../Disruptor/Sequence.cpp" />
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/YieldingWaitStrategy.cpp" />

--- a/msvc/2019/Disruptor.vcxproj.filters
+++ b/msvc/2019/Disruptor.vcxproj.filters
@@ -154,6 +154,7 @@
     <ClInclude Include="../../Disruptor/IgnoreExceptionHandler.h" />
     <ClInclude Include="../../Disruptor/SpinWaitWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/TimeoutBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IEventReleaseAware.h" />
     <ClInclude Include="../../Disruptor/IEventReleaser.h" />
     <ClInclude Include="../../Disruptor/ThreadPerTaskScheduler.h">
@@ -181,6 +182,7 @@
     </ClCompile>
     <ClCompile Include="../../Disruptor/Sequence.cpp" />
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/YieldingWaitStrategy.cpp" />

--- a/msvc/2019/Disruptor.vcxproj.filters
+++ b/msvc/2019/Disruptor.vcxproj.filters
@@ -156,6 +156,7 @@
     <ClInclude Include="../../Disruptor/TimeoutBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/LiteBlockingWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.h" />
+    <ClInclude Include="../../Disruptor/PhasedBackoffWaitStrategy.h" />
     <ClInclude Include="../../Disruptor/IEventReleaseAware.h" />
     <ClInclude Include="../../Disruptor/IEventReleaser.h" />
     <ClInclude Include="../../Disruptor/ThreadPerTaskScheduler.h">
@@ -185,6 +186,7 @@
     <ClCompile Include="../../Disruptor/BlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteBlockingWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/LiteTimeoutBlockingWaitStrategy.cpp" />
+    <ClCompile Include="../../Disruptor/PhasedBackoffWaitStrategy.cpp" />
     <ClCompile Include="../../Disruptor/FixedSequenceGroup.cpp" />
     <ClCompile Include="../../Disruptor/ProcessingSequenceBarrier.cpp" />
     <ClCompile Include="../../Disruptor/YieldingWaitStrategy.cpp" />


### PR DESCRIPTION
## What

The README states the library "implements all the features available in java Disruptor v3.3.7", but three wait strategies from the reference implementation were missing. This PR ports them, one commit each:

- **`LiteBlockingWaitStrategy`** — variation of `BlockingWaitStrategy` that elides the condition-variable notification when no consumer is actually blocked: `signalAllWhenBlocking()` only takes the lock when a waiter has raised the atomic `signalNeeded` flag, keeping the hot publishing path lock-free when the buffer isn't contended.
- **`LiteTimeoutBlockingWaitStrategy`** — the same wake-up elision applied to `TimeoutBlockingWaitStrategy`.
- **`PhasedBackoffWaitStrategy`** — busy-spins, then yields, then delegates to a configurable fallback strategy, with the three factory methods from the Java version (`withLock`, `withLiteLock`, `withSleep`).

## Notes for reviewers

- The ports follow the Java 3.3.7 logic and this codebase's existing conventions (`boost::recursive_mutex` + `boost::condition_variable_any`, `ClockConfig::Duration` timeouts, `DISRUPTOR_THROW_*` macros).
- One deliberate deviation: like the existing `TimeoutBlockingWaitStrategy`, the Lite timeout variant restarts the full timeout on each condition-variable wake-up rather than tracking remaining time as the Java version does — consistency with the sibling class seemed preferable.
- Tests mirror the Java test suite (`PhasedBackoffWaitStrategyTest`'s four delay cases, the timeout test) and the existing test style here (`assertWaitForWithDelayOf`, `SequenceBarrierMock`).
- New files are wired into CMake and all three MSVC solutions (2015/2017/2019, including `.filters`).

Replaces #24.